### PR TITLE
Added Swift Package Support & Fix OOB Read on Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,11 @@ pyhtml2md.egg-info/
 *.whl
 wheelhouse/
 tests/__pycache__/
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -11,14 +11,29 @@ let package = Package(
     targets: [
         .target(
             name: "html2md",
+            dependencies: ["html2md_cpp"],
+            path: ".",
+            sources: [
+                "objc/html2md_objc.mm",
+            ],
+            publicHeadersPath: "objc/include",
+            cxxSettings: [
+                // header is inherited from html2md_cpp
+                // we should compile this objc file with c++11
+                .unsafeFlags(["-std=c++11"]),
+            ]
+        ),
+        .target(
+            name: "html2md_cpp",
             path: ".",
             sources: [
                 "src/html2md.cpp",
-                "src/table.h",
+                "src/table.cpp",
             ],
             publicHeadersPath: "include",
             cxxSettings: [
                 .unsafeFlags(["-std=c++11"]),
+                .unsafeFlags(["-Wno-parentheses", "-Wno-conversion"]),
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "html2md",
+    products: [
+        .library(name: "html2md", targets: ["html2md"]),
+    ],
+    targets: [
+        .target(
+            name: "html2md",
+            path: ".",
+            sources: [
+                "src/html2md.cpp",
+                "src/table.h",
+            ],
+            publicHeadersPath: "include",
+            cxxSettings: [
+                .unsafeFlags(["-std=c++11"]),
+            ]
+        ),
+    ]
+)

--- a/include/html2md.h
+++ b/include/html2md.h
@@ -579,7 +579,8 @@ private:
   bool ReplacePreviousSpaceInLineByNewline();
 
   static inline bool IsIgnoredTag(const std::string &tag) {
-    return (tag[0] == '-' || kTagTemplate == tag || kTagStyle == tag ||
+    return (tag.empty() ||
+            tag[0] == '-' || kTagTemplate == tag || kTagStyle == tag ||
             kTagScript == tag || kTagNoScript == tag || kTagNav == tag);
 
     // meta: not ignored to tolerate if closing is omitted

--- a/objc/html2md_objc.mm
+++ b/objc/html2md_objc.mm
@@ -1,0 +1,24 @@
+//
+//  html2md.m
+//  html2md
+//
+//  Created by 秋星桥 on 2/17/25.
+//
+
+#import <Foundation/Foundation.h>
+
+#include "html2md.h"
+#include "include/html2md_objc.h"
+
+#include <string>
+
+@implementation HTML2MD
+
++ (NSString *)convertHTMLToMarkdown:(NSString *)html {
+    const char *htmlStr = [html UTF8String];
+    std::string outputMarkdown = html2md::Convert(htmlStr);
+    NSString *markdownStr = [NSString stringWithUTF8String:outputMarkdown.c_str()];
+    return markdownStr;
+}
+
+@end

--- a/objc/include/html2md_objc.h
+++ b/objc/include/html2md_objc.h
@@ -1,0 +1,19 @@
+//
+//  Header.h
+//  html2md
+//
+//  Created by 秋星桥 on 2/17/25.
+//
+
+#ifndef html2md_objc_h
+#define html2md_objc_h
+
+#include <Foundation/Foundation.h>
+
+@interface HTML2MD : NSObject
+
++ (NSString *)convertHTMLToMarkdown:(NSString *)html;
+
+@end
+
+#endif /* html2md_objc_h */

--- a/src/html2md.cpp
+++ b/src/html2md.cpp
@@ -442,7 +442,11 @@ bool Converter::OnHasLeftTag() {
     if (TagContainsAttributesToHide(&current_tag_))
       return true;
 
-  current_tag_ = Split(current_tag_, ' ')[0];
+  auto cut_tags = Split(current_tag_, ' ');
+  if (cut_tags.empty())
+    return true;
+
+  current_tag_ = cut_tags[0];
 
   auto tag = tags_[current_tag_];
 

--- a/src/table.cpp
+++ b/src/table.cpp
@@ -67,6 +67,10 @@ string formatMarkdownTable(const string &inputTable) {
     }
   }
 
+  if (tableData.empty()) { 
+    return ""; 
+  }
+
   // Determine maximum width of each column
   vector<size_t> columnWidths(tableData[0].size(), 0);
   for (const auto &row : tableData) {


### PR DESCRIPTION
This PR adds Swift Package Manager support and fixes an out-of-bounds read issue when handling tags.

## Changes
- Added Swift Package Manager support through `Package.swift` file
- Fixed potential out-of-bounds read in tag handling code

## Test
- I have tested it with my AI spider.

<img width="1647" alt="截屏2025-02-17 下午6 11 15" src="https://github.com/user-attachments/assets/5444cbbe-cedd-4fe5-856b-38c320c9b5c6" />
