### PR TITLE
Allow building in GCC15.

### DIFF
--- a/include/html2md.h
+++ b/include/html2md.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 /*!
  * \brief html2md namespace


### PR DESCRIPTION
From https://github.com/sbmlteam/libsbml/issues/439 via @vincent-noel:

```
In file included from D:/a/_temp/msys64/tmp/libsbml-5.20.5/src/sbml/html2md/html2md.cpp:4:
D:/a/_temp/msys64/tmp/libsbml-5.20.5/src/sbml/html2md/html2md.h:322:3: error: 'uint8_t' does not name a type
  322 |   uint8_t index_ol = 0;
      |   ^~~~~~~
D:/a/_temp/msys64/tmp/libsbml-5.20.5/src/sbml/html2md/html2md.h:10:1: note: 'uint8_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    9 | #include <unordered_map>
  +++ |+#include <cstdint>
   10 |
```